### PR TITLE
Clean version before parsing.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'bflad417@gmail.com'
 license 'Apache 2.0'
 description 'Installs wkhtmltoimage and wkhtmltopdf'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.2.0'
+version '0.2.1'
 
 recipe 'wkhtmltopdf', 'Installs wkhtmltoimage and wkhtmltopdf'
 recipe 'wkhtmltopdf::binary', 'Installs wkhtmltoimage and wkhtmltopdf binaries'

--- a/recipes/binary.rb
+++ b/recipes/binary.rb
@@ -1,6 +1,14 @@
 cache_dir = Chef::Config[:file_cache_path]
 download_dest = File.join(cache_dir, node['wkhtmltopdf']['archive'])
-wkhtmltopdf_version = Chef::Version.new(node['wkhtmltopdf']['version'])
+clean_version =  if (match = /^(\d+)\.(\d+)\.(\d+)/.match(node['wkhtmltopdf']['version']))
+    "#{match[1]}.#{match[2]}.#{match[3]}"
+  elsif (match = /^(\d+)\.(\d+)/.match(node['wkhtmltopdf']['version']))
+        "#{match[1]}.#{match[2]}"
+  else
+    node['wkhtmltopdf']['version']
+  end 
+wkhtmltopdf_version = Chef::Version.new(clean_version)
+
 
 remote_file download_dest do
   source node['wkhtmltopdf']['mirror_url']


### PR DESCRIPTION
Chef::Version is only intended for cookbook versions, and as such can only handle x.y.z or x.y formats. It won't handle .pre, or .rc etc...

This strips just the leading version part that Chef::Version can understand.
