### PR TITLE
Update binary locations and update debian dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - test/**/*
     - vendor/**/*
     - ruby/**/*
+    - Vagrantfile
 
 AlignParameters:
   Enabled: false
@@ -19,3 +20,5 @@ LineLength:
   Enabled: false
 MethodLength:
   Max: 30
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 bundler_args: --without integration
 rvm:
-  - 1.9.3
+  - 2.4.2
 before_script:
   - bundle exec berks install
 script:

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-source "https://supermarket.chef.io"
+source 'https://supermarket.chef.io'
 
 metadata

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-site :opscode
+source "https://supermarket.chef.io"
 
 metadata

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ group :test, :integration do
 end
 
 group :test do
-  gem 'chefspec', '~> 4.0'
-  gem 'foodcritic', '~> 3.0.3'
-  gem 'rubocop', '~> 0.23'
+  gem 'chefspec', '~> 7.1.0'
+  gem 'foodcritic', '~> 11.4.0'
+  gem 'rubocop', '~> 0.50.0'
 end
 
 group :integration do

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'rake'
 
 group :test, :integration do
-  gem 'berkshelf', '~> 2.0.14'
+  gem 'berkshelf', '~> 6.3.1'
 end
 
 group :test do

--- a/Guardfile
+++ b/Guardfile
@@ -1,7 +1,6 @@
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 
-# rubocop:disable RegexpLiteral
 guard 'kitchen' do
   watch(%r{test/.+})
   watch(%r{^recipes/(.+)\.rb$})
@@ -11,4 +10,3 @@ guard 'kitchen' do
   watch(%r{^providers/(.+)\.rb})
   watch(%r{^resources/(.+)\.rb})
 end
-# rubocop:enable RegexpLiteral

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installs [wkhtmltopdf](http://wkhtmltopdf.org) static binaries. This cookbook is
 
 Cookbook Compatibility:
  * chef-wkhtmltopdf 0.1.0: wkhtmltopdf 0.11.0_rc1
- * chef-wkhtmltopdf 0.2.0: wkhtmltopdf 0.12.0
+ * chef-wkhtmltopdf 0.2.0: wkhtmltopdf 0.12.4
 
 ## Requirements
 
@@ -15,6 +15,7 @@ Cookbook Compatibility:
 * CentOS 6
 * RedHat 6
 * Ubuntu 12.04
+* Ubuntu 16.04
 
 ### Cookbooks
 
@@ -28,8 +29,7 @@ These attributes are under the `node['wkhtmltopdf']` namespace.
 
 Attribute | Description | Type | Default
 ----------|-------------|------|--------
-archive | wkhtmltopdf archive name | String | `wkhtmltox-#{node['wkhtmltopdf']['platform']}_#{node['wkhtmltopdf']['version']}-#{node['wkhtmltopdf']['build_sha']}.tar.xz`
-build_sha | wkhtmltopdf build SHA | String | 03c001d
+archive | wkhtmltopdf archive name | String | `wkhtmltox-#{node['wkhtmltopdf']['version']}_#{node['wkhtmltopdf']['platform']}`
 dependency_packages | Packages that contain wkhtmltopdf dependencies | String | (auto-detected, see attributes/default.rb)
 install_dir | directory to install static binaries | String | /usr/local/bin
 lib_dir | directory to install libraries | String | ''
@@ -55,7 +55,7 @@ Here's how you can quickly get testing or developing against the cookbook thanks
     vagrant plugin install vagrant-omnibus
     git clone git://github.com/bflad/chef-wkhtmltopdf.git
     cd chef-wkhtmltopdf
-    vagrant up BOX # BOX being centos5, centos6, debian7, fedora18, fedora19, fedora20, freebsd9, ubuntu1204, ubuntu1210, ubuntu1304, or ubuntu1310
+    vagrant up BOX # BOX being centos5, centos6, debian7, fedora18, fedora19, fedora20, freebsd9, ubuntu1204, ubuntu1210, ubuntu1304, ubuntu1310, or ubuntu1604
 
 You can then SSH into the running VM using the `vagrant ssh BOX` command.
 

--- a/Rakefile
+++ b/Rakefile
@@ -58,7 +58,7 @@ end
 task unit: ['unit:rspec']
 
 desc 'Run all tests on Travis'
-task travis: %w(style unit)
+task travis: %w[style unit]
 
 # Default
 task default: ['style', 'unit', 'integration:kitchen:all']

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,6 +72,12 @@ Vagrant.configure('2') do |config|
     ubuntu1310.vm.hostname = "#{cookbook}-ubuntu-1310"
   end
 
+  config.vm.define :ubuntu1604 do |ubuntu1604|
+    ubuntu1604.vm.box      = 'opscode-ubuntu-16.04'
+    ubuntu1604.vm.box_url  = 'http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-16.04_chef-provisionerless.box'
+    ubuntu1604.vm.hostname = "#{cookbook}-ubuntu-1604"
+  end
+
   config.vm.network :private_network, ip: '192.168.50.10'
 
   config.vm.provider 'virtualbox' do |v|

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,18 +1,17 @@
-default['wkhtmltopdf']['version']     = '0.12.0'
-default['wkhtmltopdf']['build_sha']   = '03c001d'
+default['wkhtmltopdf']['version']     = '0.12.3'
 default['wkhtmltopdf']['install_dir'] = '/usr/local/bin'
 default['wkhtmltopdf']['lib_dir']     = ''
 
 case node['platform_family']
 when 'mac_os_x', 'mac_os_x_server'
   default['wkhtmltopdf']['dependency_packages'] = []
-  default['wkhtmltopdf']['platform'] = 'macosx-10.9.1-x86_64'
+  default['wkhtmltopdf']['platform'] = 'osx-cocoa-x86-64.pkg'
 when 'windows'
   default['wkhtmltopdf']['dependency_packages'] = []
   if node['kernel']['machine'] == 'x86_64'
-    default['wkhtmltopdf']['platform'] = 'win64'
+    default['wkhtmltopdf']['platform'] = 'msvc2015-win64.exe'
   else
-    default['wkhtmltopdf']['platform'] = 'win32'
+    default['wkhtmltopdf']['platform'] = 'msvc2015-win32.exe'
   end
 else
   default['wkhtmltopdf']['dependency_packages'] = value_for_platform_family(
@@ -20,11 +19,13 @@ else
     %w(fedora rhel) => %w(fontconfig libXext libXrender openssl-devel urw-fonts)
   )
   if node['kernel']['machine'] == 'x86_64'
-    default['wkhtmltopdf']['platform'] = 'linux-amd64'
+    default['wkhtmltopdf']['platform'] = 'linux-generic-amd64.tar.xz'
   else
-    default['wkhtmltopdf']['platform'] = 'linux-i386'
+    default['wkhtmltopdf']['platform'] = 'linux-generic-i386.tar.xz'
   end
 end
 
-default['wkhtmltopdf']['archive']     = "wkhtmltox-#{node['wkhtmltopdf']['platform']}_#{node['wkhtmltopdf']['version']}-#{node['wkhtmltopdf']['build_sha']}.tar.xz"
-default['wkhtmltopdf']['mirror_url']  = "http://downloads.sourceforge.net/project/wkhtmltopdf/#{node['wkhtmltopdf']['version']}/#{node['wkhtmltopdf']['archive']}"
+#default['wkhtmltopdf']['archive']     = "wkhtmltox-#{node['wkhtmltopdf']['platform']}_#{node['wkhtmltopdf']['version']}-#{node['wkhtmltopdf']['build_sha']}.tar.xz"
+default['wkhtmltopdf']['archive']     = "wkhtmltox-#{node['wkhtmltopdf']['version']}_#{node['wkhtmltopdf']['platform']}"
+#default['wkhtmltopdf']['mirror_url']  = "http://downloads.sourceforge.net/project/wkhtmltopdf/#{node['wkhtmltopdf']['version']}/#{node['wkhtmltopdf']['archive']}"
+default['wkhtmltopdf']['mirror_url']  = "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/#{node['wkhtmltopdf']['version']}/#{node['wkhtmltopdf']['archive']}"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,7 +15,7 @@ when 'windows'
   end
 else
   default['wkhtmltopdf']['dependency_packages'] = value_for_platform_family(
-    %w(debian) => %w(libfontconfig1 libssl0.9.8 libxext6 libxrender1),
+    %w(debian) => %w(zlib1g-dev libfontconfig1 libfreetype6-dev libx11-dev libxext6 libxrender1),
     %w(fedora rhel) => %w(fontconfig libXext libXrender openssl-devel urw-fonts)
   )
   if node['kernel']['machine'] == 'x86_64'
@@ -25,7 +25,5 @@ else
   end
 end
 
-#default['wkhtmltopdf']['archive']     = "wkhtmltox-#{node['wkhtmltopdf']['platform']}_#{node['wkhtmltopdf']['version']}-#{node['wkhtmltopdf']['build_sha']}.tar.xz"
 default['wkhtmltopdf']['archive']     = "wkhtmltox-#{node['wkhtmltopdf']['version']}_#{node['wkhtmltopdf']['platform']}"
-#default['wkhtmltopdf']['mirror_url']  = "http://downloads.sourceforge.net/project/wkhtmltopdf/#{node['wkhtmltopdf']['version']}/#{node['wkhtmltopdf']['archive']}"
 default['wkhtmltopdf']['mirror_url']  = "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/#{node['wkhtmltopdf']['version']}/#{node['wkhtmltopdf']['archive']}"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,21 +8,21 @@ when 'mac_os_x', 'mac_os_x_server'
   default['wkhtmltopdf']['platform'] = 'osx-cocoa-x86-64.pkg'
 when 'windows'
   default['wkhtmltopdf']['dependency_packages'] = []
-  if node['kernel']['machine'] == 'x86_64'
-    default['wkhtmltopdf']['platform'] = 'msvc2015-win64.exe'
-  else
-    default['wkhtmltopdf']['platform'] = 'msvc2015-win32.exe'
-  end
+  default['wkhtmltopdf']['platform'] = if node['kernel']['machine'] == 'x86_64'
+                                         'msvc2015-win64.exe'
+                                       else
+                                         'msvc2015-win32.exe'
+                                       end
 else
   default['wkhtmltopdf']['dependency_packages'] = value_for_platform_family(
-    %w(debian) => %w(zlib1g-dev libfontconfig1 libfreetype6-dev libx11-dev libxext6 libxrender1),
-    %w(fedora rhel) => %w(fontconfig libXext libXrender openssl-devel urw-fonts)
+    %w[debian] => %w[zlib1g-dev libfontconfig1 libfreetype6-dev libx11-dev libxext6 libxrender1],
+    %w[fedora rhel] => %w[fontconfig libXext libXrender openssl-devel urw-fonts]
   )
-  if node['kernel']['machine'] == 'x86_64'
-    default['wkhtmltopdf']['platform'] = 'linux-generic-amd64.tar.xz'
-  else
-    default['wkhtmltopdf']['platform'] = 'linux-generic-i386.tar.xz'
-  end
+  default['wkhtmltopdf']['platform'] = if node['kernel']['machine'] == 'x86_64'
+                                         'linux-generic-amd64.tar.xz'
+                                       else
+                                         'linux-generic-i386.tar.xz'
+                                       end
 end
 
 default['wkhtmltopdf']['archive']     = "wkhtmltox-#{node['wkhtmltopdf']['version']}_#{node['wkhtmltopdf']['platform']}"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-default['wkhtmltopdf']['version']     = '0.12.3'
+default['wkhtmltopdf']['version']     = '0.12.4'
 default['wkhtmltopdf']['install_dir'] = '/usr/local/bin'
 default['wkhtmltopdf']['lib_dir']     = ''
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,13 @@
 name 'wkhtmltopdf'
 maintainer 'Brian Flad'
 maintainer_email 'bflad417@gmail.com'
-license 'Apache 2.0'
+license 'Apache-2.0'
 description 'Installs wkhtmltoimage and wkhtmltopdf'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.2.0'
+chef_version '>= 12.0'
+source_url 'https://github.com/bflad/chef-wkhtmltopdf'
+issues_url 'https://github.com/bflad/chef-wkhtmltopdf/issues'
 
 recipe 'wkhtmltopdf', 'Installs wkhtmltoimage and wkhtmltopdf'
 recipe 'wkhtmltopdf::binary', 'Installs wkhtmltoimage and wkhtmltopdf binaries'


### PR DESCRIPTION
closes #12 

- update binary versions to the ones suggested on: https://wkhtmltopdf.org/downloads.html (source forge binary locations are returning 404 errors)
- update debian dependency list to match what is listed at the download site linked above
- add ubuntu1604 vm for testing
- replace `site` with `source` as suggested by latest chef version in Berksfile
- bump default wkhtmltopdf version to the latest (12.04)
- tested against ubuntu1604